### PR TITLE
Fixes few UI issues with paddings and sizes of lists

### DIFF
--- a/docusaurus/website/static/css/custom.css
+++ b/docusaurus/website/static/css/custom.css
@@ -36,7 +36,7 @@
     border-radius: 6px;
     padding: 15px;
     font-size: 15px;
-  
+
     /* respect the section's max width, from .mainContainer .wrapper p */
     max-width: 40rem;
 }
@@ -56,13 +56,10 @@ a {
 .container {
     margin-left: auto;
     margin-right: auto;
-    text-align: center;
 }
 
 .container ul {
-    width: 35%;
     margin: auto;
-    display: inline-block;
 
     /* One most likely needs to realign flow content */
     text-align: initial;
@@ -75,4 +72,16 @@ pre {
     white-space: -moz-pre-wrap;
     white-space: -o-pre-wrap;
     white-space: -ms-pre-wrap;
+}
+
+/* Matches lists padding with paragraphs padding on the main site */
+.productShowcaseSection ul {
+    margin: 0 auto;
+    max-width: 560px;
+    padding: 0.8em 2em;
+}
+
+/* Adds small padding in TOC menu items */
+.toc .toggleNav ul {
+    padding: 0 8px;
 }


### PR DESCRIPTION
There are couple of issues with styles making it hard to read specs on desktop, and almost impossible on mobile. This PR fixes them. Few examples:

1.  Before:
<img width="1180" alt="screen shot 2018-10-16 at 18 42 05" src="https://user-images.githubusercontent.com/1357927/47032783-7e95f080-d173-11e8-888d-f549b050b3e6.png">
After:
<img width="1180" alt="screen shot 2018-10-16 at 18 42 07" src="https://user-images.githubusercontent.com/1357927/47032787-82c20e00-d173-11e8-821e-601150e2e88d.png">

2. Before:
<img width="1180" alt="screen shot 2018-10-16 at 18 42 51" src="https://user-images.githubusercontent.com/1357927/47032821-94a3b100-d173-11e8-99df-efc4a00be260.png">
After:
<img width="1180" alt="screen shot 2018-10-16 at 18 42 52" src="https://user-images.githubusercontent.com/1357927/47032829-98cfce80-d173-11e8-9b81-d4470e8d3456.png">

It changes also a bit how lists are presented on the main page. A matter of taste if it's better or worse:

Before:
<img width="1180" alt="screen shot 2018-10-16 at 18 45 46" src="https://user-images.githubusercontent.com/1357927/47032912-ce74b780-d173-11e8-84dd-4b48d2e264ed.png">
After:
<img width="1180" alt="screen shot 2018-10-16 at 18 45 47" src="https://user-images.githubusercontent.com/1357927/47032920-d16fa800-d173-11e8-8489-dfb20c3f436b.png">



Fixes #4 